### PR TITLE
⚡ Variable hashCode

### DIFF
--- a/src/main/java/edu/wisc/cs/will/FOPC/Variable.java
+++ b/src/main/java/edu/wisc/cs/will/FOPC/Variable.java
@@ -4,10 +4,7 @@ import edu.wisc.cs.will.FOPC.visitors.TermVisitor;
 import edu.wisc.cs.will.Utils.Utils;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class Variable extends Term {
 
@@ -371,5 +368,9 @@ public class Variable extends Term {
     }
 
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, counter);
+    }
 }
 


### PR DESCRIPTION
Add `hashCode()` in `FOPC.Variable`

This should resolve one of the main errors LGTM currently points
out: that `Variable` is heavily used in HashMaps but doesn't
define a `hashCode`